### PR TITLE
Fix code scanning alert no. 2: Email content injection

### DIFF
--- a/backend/internal/utils/email_manager.go
+++ b/backend/internal/utils/email_manager.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"html/template"
 	"log"
 	"net/smtp"
 	"os"
@@ -31,12 +32,14 @@ func SendVerificationEmail(user models.User, sender EmailSender) error {
 
 	// Compose the email content
 	subject := "Email Verification"
+	escapedUsername := template.HTMLEscapeString(user.Username)
+	escapedVerificationURL := template.HTMLEscapeString(verificationURL)
 	body := fmt.Sprintf(`
 		<p>Hello %s,</p>
 		<p>Thank you for registering with us. Please verify your email address by clicking the link below:</p>
 		<a href="%s">%s</a>
 		<p>If you did not request this, please ignore this email.</p>
-	`, user.Username, verificationURL, verificationURL)
+	`, escapedUsername, escapedVerificationURL, escapedVerificationURL)
 
 	// Set up the email message
 	from := os.Getenv("SMTP_USERNAME")


### PR DESCRIPTION
Fixes [https://github.com/JoaquimFontesMatos/PeakNovelGo/security/code-scanning/2](https://github.com/JoaquimFontesMatos/PeakNovelGo/security/code-scanning/2)

To fix the problem, we need to sanitize the user-provided data before using it to construct the email body. This can be achieved by escaping any potentially harmful characters in the user data. We can use the `html/template` package in Go to escape the user data before including it in the email body.

1. Import the `html/template` package.
2. Use the `template.HTMLEscapeString` function to escape user data before including it in the email body.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
